### PR TITLE
Add ShowClientsCommand and parser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ShowClientsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowClientsCommand.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Show all the cleints associated to a property
+ */
+public class ShowClientsCommand extends Command {
+
+    public static final String COMMAND_WORD = "showclients";
+    private final String propertyId;
+
+    public ShowClientsCommand(String propertyId) {
+        this.propertyId = propertyId;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        // TODO: implement when Property and Link classes are ready
+        return new CommandResult("Feature coming up soon. Property ID: " + propertyId);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ShowClientsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ShowClientsCommand.COMMAND_WORD:
+            return new ShowClientsCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ShowClientsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowClientsCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ShowClientsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parse the input for ShowClientsCommand
+ */
+public class ShowClientsCommandParser implements Parser<ShowClientsCommand> {
+
+    @Override
+    public ShowClientsCommand parse(String userInput) throws ParseException {
+        String trimmedArgs = userInput.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException("Property ID cannot be empty");
+        }
+
+        // Check if input starts with "p/"
+        if (!trimmedArgs.startsWith("p/")) {
+            throw new ParseException("Invalid format. Use the following: showclients p/PROPERTY_ID");
+        }
+
+        // Extract everything after "p/"
+        String propertyId = trimmedArgs.substring(2).trim();
+
+        if (propertyId.isEmpty()) {
+            throw new ParseException("Property ID cannot be empty");
+        }
+
+        return new ShowClientsCommand(propertyId);
+    }
+}


### PR DESCRIPTION
Add basic ShowClientCommand feature structure.

- Add ShowClientsCommand with placeholder implementation
- Add ShowClientsCommandParser to parse p/PROPERTY_ID format
- Add ShowClientsCommand to the AddressBookParser
- Command is now functional in the application

##Testing
- Manually tested with 'showclients p/123' - successfully returns placeholder message
- Waiting for Property and Link classes before adding the test code