### PR TITLE
Enhance showproperties to show all client-property relationships

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ShowPropertiesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowPropertiesCommand.java
@@ -2,41 +2,37 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Uuid;
-import seedu.address.model.property.OwnerMatchesPredicate;
+import seedu.address.model.property.Property;
 
 /**
- * Finds and lists all properties where the specified client is the owner.
- *
- * Note: This code currently only shows properties where client is the owner only.
- * Future enhancement: Show all properties linked to client (as buyer, seller, etc.)
- * when property-client association model is implemented.
+ * Finds and lists all properties associated with a specified client.
+ * Shows properties where the client is the owner, buyer, or seller.
  */
 public class ShowPropertiesCommand extends Command {
 
     public static final String COMMAND_WORD = "showproperties";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Shows all properties owned by the specified client.\n"
+            + ": Shows all properties associated with the specified client.\n"
             + "Parameters: c/CLIENT_UUID (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " c/123";
 
-    public static final String MESSAGE_SUCCESS = "Listed %2$d propert%3$s owned by client UUID: %1$s";
-
-    public static final String MESSAGE_NO_PROPERTIES =
-            "No properties found owned by client UUID: %1$s\n"
-                    + "Possible reasons:\n"
-                    + "  • The client exists but doesn't own any properties yet\n"
-                    + "  • The client UUID doesn't exist (use 'list' to verify)\n"
-                    + "Tip: Use 'addproperty ... owner/%1$s' to add a property for this client.";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Person with UUID %s not found.";
+    public static final String MESSAGE_NO_PROPERTIES = "Client UUID %s has no associated properties.";
 
     private final Uuid clientUuid;
 
     /**
-     * Creates a ShowPropertiesCommand to find all properties owned by the specified client.
+     * Creates a ShowPropertiesCommand to find all properties associated with the specified client.
      *
      * @param clientUuid The UUID of the client to search for.
      */
@@ -49,20 +45,133 @@ public class ShowPropertiesCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Filter properties where owner matches the client UUID
-        OwnerMatchesPredicate predicate = new OwnerMatchesPredicate(clientUuid);
-        model.updateFilteredPropertyList(predicate);
+        // Find the target person from the person list
+        String clientUuidString = clientUuid.toString();
+        Person targetPerson = null;
 
-        int numPropertiesFound = model.getFilteredPropertyList().size();
-
-        if (numPropertiesFound == 0) {
-            return new CommandResult(String.format(MESSAGE_NO_PROPERTIES, clientUuid));
+        for (Person person : model.getFilteredPersonList()) {
+            if (person.getUuid().toString().equals(clientUuidString)) {
+                targetPerson = person;
+                break;
+            }
         }
 
-        // Grammatically correct: "1 property" vs "2 properties"
-        String propertyWord = numPropertiesFound == 1 ? "y" : "ies";
-        return new CommandResult(
-                String.format(MESSAGE_SUCCESS, clientUuid, numPropertiesFound, propertyWord));
+        if (targetPerson == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, clientUuid));
+        }
+
+        // Get all properties
+        List<Property> allProperties = model.getFilteredPropertyList();
+
+        // Find properties where client is OWNER
+        List<Property> ownerProperties = new ArrayList<>();
+        for (Property property : allProperties) {
+            if (property.getOwner().value.equals(clientUuidString)) {
+                ownerProperties.add(property);
+            }
+        }
+
+        // Find properties where client is BUYER
+        Set<String> buyingPropertyIds = targetPerson.getBuyingPropertyIds();
+        List<Property> buyerProperties = new ArrayList<>();
+        for (Property property : allProperties) {
+            if (buyingPropertyIds.contains(property.getId())) {
+                buyerProperties.add(property);
+            }
+        }
+
+        // Find properties where client is SELLER
+        Set<String> sellingPropertyIds = targetPerson.getSellingPropertyIds();
+        List<Property> sellerProperties = new ArrayList<>();
+        for (Property property : allProperties) {
+            if (sellingPropertyIds.contains(property.getId())) {
+                sellerProperties.add(property);
+            }
+        }
+
+        // Check if client has any properties
+        int totalProperties = ownerProperties.size() + buyerProperties.size() + sellerProperties.size();
+        if (totalProperties == 0) {
+            throw new CommandException(String.format(MESSAGE_NO_PROPERTIES, clientUuidString));
+        }
+
+        // Build formatted output
+        String formattedOutput = buildFormattedOutput(
+                targetPerson, clientUuidString, ownerProperties, buyerProperties, sellerProperties, totalProperties);
+
+        return new CommandResult(formattedOutput);
+    }
+
+    /**
+     * Builds the formatted output string showing all properties grouped by relationship type.
+     */
+    private String buildFormattedOutput(Person targetPerson, String clientUuidString,
+                                        List<Property> ownerProperties,
+                                        List<Property> buyerProperties,
+                                        List<Property> sellerProperties,
+                                        int totalProperties) {
+        StringBuilder result = new StringBuilder();
+
+        // Header
+        result.append(String.format("Showing properties for Client UUID %s (%s):\n\n",
+                clientUuidString, targetPerson.getName()));
+
+        // Owner section
+        if (!ownerProperties.isEmpty()) {
+            result.append("As Owner:\n");
+            for (Property property : ownerProperties) {
+                result.append(formatPropertyLine(property));
+            }
+            result.append("\n");
+        }
+
+        // Buyer section
+        if (!buyerProperties.isEmpty()) {
+            result.append("As Buyer:\n");
+            for (Property property : buyerProperties) {
+                result.append(formatPropertyLine(property));
+            }
+            result.append("\n");
+        }
+
+        // Seller section
+        if (!sellerProperties.isEmpty()) {
+            result.append("As Seller:\n");
+            for (Property property : sellerProperties) {
+                result.append(formatPropertyLine(property));
+            }
+            result.append("\n");
+        }
+
+        // Footer with total count
+        String propertyWord = totalProperties == 1 ? "property" : "properties";
+        result.append(String.format("Total: %d %s", totalProperties, propertyWord));
+
+        return result.toString();
+    }
+
+    /**
+     * Formats a single property line for display.
+     */
+    private String formatPropertyLine(Property property) {
+        return String.format("  - Property %s: %s (%s, $%s, %s)\n",
+                property.getId(),
+                property.getPropertyAddress().value,
+                property.getType().value,
+                formatPrice(property.getPrice().value),
+                property.getStatus().value);
+    }
+
+    /**
+     * Formats the price with comma separators for readability.
+     */
+    private String formatPrice(String price) {
+        try {
+            long priceValue = Long.parseLong(price);
+            return String.format("%,d", priceValue);
+        } catch (NumberFormatException e) {
+            return price;
+        }
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ShowPropertiesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowPropertiesCommandTest.java
@@ -3,12 +3,180 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalProperties.getTypicalPropertyBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Uuid;
+import seedu.address.model.property.Property;
+import seedu.address.testutil.PersonBuilderUtil;
+import seedu.address.testutil.PropertyBuilderUtil;
 
 public class ShowPropertiesCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalPropertyBook(), new UserPrefs());
+
+    @Test
+    public void execute_clientIsOwner_success() {
+        // Create a person
+        Person person = new PersonBuilderUtil().withUuid(100).withName("Tan Wei Ming").build();
+        model.addPerson(person);
+
+        // Create a property owned by this person
+        Property property = new PropertyBuilderUtil()
+                .withId("prop100")
+                .withPropertyAddress("123 Orchard Road")
+                .withOwner("100")
+                .withPrice("1500000")
+                .build();
+        model.addProperty(property);
+
+        ShowPropertiesCommand command = new ShowPropertiesCommand(new Uuid(100));
+
+        String expectedMessage = "Showing properties for Client UUID 100 (Tan Wei Ming):\n\n"
+                + "As Owner:\n"
+                + "  - Property prop100: 123 Orchard Road (landed, $1,500,000, sold)\n\n"
+                + "Total: 1 property";
+
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_clientIsBuyer_success() {
+        // Create a person with buying property IDs
+        Person buyer = new PersonBuilderUtil()
+                .withUuid(200)
+                .withName("Lim Hui Ying")
+                .withBuyingPropertyIds("prop200")
+                .build();
+        model.addPerson(buyer);
+
+        // Create a property that the person wants to buy
+        Property property = new PropertyBuilderUtil()
+                .withId("prop200")
+                .withPropertyAddress("456 Toa Payoh Lorong 6")
+                .withOwner("999")
+                .withPrice("650000")
+                .build();
+        model.addProperty(property);
+
+        ShowPropertiesCommand command = new ShowPropertiesCommand(new Uuid(200));
+
+        String expectedMessage = "Showing properties for Client UUID 200 (Lim Hui Ying):\n\n"
+                + "As Buyer:\n"
+                + "  - Property prop200: 456 Toa Payoh Lorong 6 (landed, $650,000, sold)\n\n"
+                + "Total: 1 property";
+
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_clientIsSeller_success() {
+        // Create a person with selling property IDs
+        Person seller = new PersonBuilderUtil()
+                .withUuid(300)
+                .withName("Kumar Rajan")
+                .withSellingPropertyIds("prop300")
+                .build();
+        model.addPerson(seller);
+
+        // Create a property that the person wants to sell
+        Property property = new PropertyBuilderUtil()
+                .withId("prop300")
+                .withPropertyAddress("789 Bukit Timah Road")
+                .withOwner("888")
+                .withPrice("2800000")
+                .build();
+        model.addProperty(property);
+
+        ShowPropertiesCommand command = new ShowPropertiesCommand(new Uuid(300));
+
+        String expectedMessage = "Showing properties for Client UUID 300 (Kumar Rajan):\n\n"
+                + "As Seller:\n"
+                + "  - Property prop300: 789 Bukit Timah Road (landed, $2,800,000, sold)\n\n"
+                + "Total: 1 property";
+
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_clientHasMultipleRoles_success() {
+        // Create a person with multiple property relationships
+        Person person = new PersonBuilderUtil()
+                .withUuid(400)
+                .withName("Chen Xiao Li")
+                .withBuyingPropertyIds("prop401")
+                .withSellingPropertyIds("prop402")
+                .build();
+        model.addPerson(person);
+
+        // Property owned by the person
+        Property ownedProperty = new PropertyBuilderUtil()
+                .withId("prop400")
+                .withPropertyAddress("100 Marine Parade Central")
+                .withOwner("400")
+                .withPrice("1200000")
+                .build();
+        model.addProperty(ownedProperty);
+
+        // Property the person wants to buy
+        Property buyingProperty = new PropertyBuilderUtil()
+                .withId("prop401")
+                .withPropertyAddress("200 Clementi Avenue 2")
+                .withOwner("999")
+                .withPrice("850000")
+                .build();
+        model.addProperty(buyingProperty);
+
+        // Property the person wants to sell
+        Property sellingProperty = new PropertyBuilderUtil()
+                .withId("prop402")
+                .withPropertyAddress("300 Tampines Street 21")
+                .withOwner("888")
+                .withPrice("700000")
+                .build();
+        model.addProperty(sellingProperty);
+
+        ShowPropertiesCommand command = new ShowPropertiesCommand(new Uuid(400));
+
+        String expectedMessage = "Showing properties for Client UUID 400 (Chen Xiao Li):\n\n"
+                + "As Owner:\n"
+                + "  - Property prop400: 100 Marine Parade Central (landed, $1,200,000, sold)\n\n"
+                + "As Buyer:\n"
+                + "  - Property prop401: 200 Clementi Avenue 2 (landed, $850,000, sold)\n\n"
+                + "As Seller:\n"
+                + "  - Property prop402: 300 Tampines Street 21 (landed, $700,000, sold)\n\n"
+                + "Total: 3 properties";
+
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_clientHasNoProperties_throwsCommandException() {
+        // Create a person with no property associations
+        Person person = new PersonBuilderUtil().withUuid(500).withName("David Ng").build();
+        model.addPerson(person);
+
+        ShowPropertiesCommand command = new ShowPropertiesCommand(new Uuid(500));
+
+        assertCommandFailure(command, model, String.format(
+                ShowPropertiesCommand.MESSAGE_NO_PROPERTIES, "500"));
+    }
+
+    @Test
+    public void execute_personNotFound_throwsCommandException() {
+        ShowPropertiesCommand command = new ShowPropertiesCommand(new Uuid(999));
+
+        assertCommandFailure(command, model, String.format(
+                ShowPropertiesCommand.MESSAGE_PERSON_NOT_FOUND, "999"));
+    }
 
     @Test
     public void equals() {
@@ -18,20 +186,20 @@ public class ShowPropertiesCommandTest {
         ShowPropertiesCommand showFirstCommand = new ShowPropertiesCommand(firstUuid);
         ShowPropertiesCommand showSecondCommand = new ShowPropertiesCommand(secondUuid);
 
-        // same object will returns true
+        // same object returns true
         assertTrue(showFirstCommand.equals(showFirstCommand));
 
-        // same values will return true
+        // same values return true
         ShowPropertiesCommand showFirstCommandCopy = new ShowPropertiesCommand(firstUuid);
         assertTrue(showFirstCommand.equals(showFirstCommandCopy));
 
-        // different types will return false
+        // different types return false
         assertFalse(showFirstCommand.equals(1));
 
-        // null value will returns false
+        // null value returns false
         assertFalse(showFirstCommand.equals(null));
 
-        // different uuid will return false
+        // different uuid returns false
         assertFalse(showFirstCommand.equals(showSecondCommand));
     }
 

--- a/src/test/java/seedu/address/logic/parser/ShowPropertiesCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowPropertiesCommandParserTest.java
@@ -1,0 +1,159 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLIENT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.ShowPropertiesCommand;
+import seedu.address.model.person.Uuid;
+
+/**
+ * Contains unit tests for {@code ShowPropertiesCommandParser}.
+ */
+public class ShowPropertiesCommandParserTest {
+
+    private final ShowPropertiesCommandParser parser = new ShowPropertiesCommandParser();
+
+    @Test
+    public void parse_validSingleDigitUuid_success() {
+        String userInput = " c/1";
+        ShowPropertiesCommand expectedCommand = new ShowPropertiesCommand(new Uuid(1));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validMultipleDigitUuid_success() {
+        String userInput = " c/123";
+        ShowPropertiesCommand expectedCommand = new ShowPropertiesCommand(new Uuid(123));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validLargeUuid_success() {
+        String userInput = " c/999999";
+        ShowPropertiesCommand expectedCommand = new ShowPropertiesCommand(new Uuid(999999));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validWithExtraSpaces_success() {
+        String userInput = "   c/123   ";
+        ShowPropertiesCommand expectedCommand = new ShowPropertiesCommand(new Uuid(123));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validWithLeadingZeros_success() {
+        String userInput = " c/00123";
+        ShowPropertiesCommand expectedCommand = new ShowPropertiesCommand(new Uuid(123));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingPrefix_failure() {
+        String userInput = " 123";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowPropertiesCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArgs_failure() {
+        String userInput = "";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowPropertiesCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_onlyWhitespace_failure() {
+        String userInput = "   ";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowPropertiesCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_onlyPrefixNoValue_failure() {
+        String userInput = " c/";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_onlyPrefixWithSpaces_failure() {
+        String userInput = " c/   ";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_nonNumericUuid_failure() {
+        String userInput = " c/abc";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_negativeUuid_failure() {
+        String userInput = " c/-123";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_uuidWithSpecialCharacters_failure() {
+        String userInput = " c/12@34";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_uuidWithSpaces_failure() {
+        String userInput = " c/12 34";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_decimalUuid_failure() {
+        String userInput = " c/12.34";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_uuidWithLetters_failure() {
+        String userInput = " c/12a34";
+        assertParseFailure(parser, userInput, Uuid.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_duplicatePrefix_failure() {
+        String userInput = " c/123 c/456";
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_CLIENT));
+    }
+
+    @Test
+    public void parse_multipleDuplicatePrefix_failure() {
+        String userInput = " c/1 c/2 c/3";
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_CLIENT));
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        String userInput = "extra c/123";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowPropertiesCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_numberInPreamble_failure() {
+        String userInput = "999 c/123";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowPropertiesCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_wrongPrefix_failure() {
+        String userInput = " p/123";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowPropertiesCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
## Changes
Enhanced `showproperties c/CLIENT_UUID` command to show all property relationships, not just owner properties.

## Features Added
- Shows properties where client is **owner**
- Shows properties where client is **buyer** 
- Shows properties where client is **seller**
- Groups output by relationship type
- Displays total property count

## Example Output
```
Showing properties for Client UUID 1 (Tan Wei Ming):

As Owner:
  - Property abc123: 123 Orchard Road (condo, $1,500,000, listed)

As Buyer:
  - Property def456: 456 Toa Payoh Lorong 6 (hdb, $650,000, listed)

Total: 2 properties
```

## Tests
- Completed comprehensive tests for the parser and the command logic
- Manual testing completed

## Files Modified
- `ShowPropertiesCommand.java` - Enhanced the execute() logic
- `ShowPropertiesCommandTest.java` - Added more comprehensive tests
- `ShowPropertiesCommandParserTest.java` - New parser test file
