### PR TITLE
Improve GUI: Display all property fields on separate lines

### DIFF
--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -90,8 +90,8 @@ public class ContactCard extends UiPart<Region> {
         setTagsIfNotEmpty(contact);
 
         // Property IDs
-        setIdsIfNotEmpty(buyingIds, "Buying IDs: ", contact.getBuyingPropertyIds());
-        setIdsIfNotEmpty(sellingIds, "Selling IDs: ", contact.getSellingPropertyIds());
+        setIdsIfNotEmpty(buyingIds, "Buying Property IDs: ", contact.getBuyingPropertyIds());
+        setIdsIfNotEmpty(sellingIds, "Selling Property IDs: ", contact.getSellingPropertyIds());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PropertyCard.java
+++ b/src/main/java/seedu/address/ui/PropertyCard.java
@@ -25,13 +25,27 @@ public class PropertyCard extends UiPart<Region> {
     @FXML
     private Label propertyAddress;
     @FXML
-    private Label details;
-    @FXML
     private Label price;
     @FXML
-    private Label linkedIds;
+    private Label postal;
+    @FXML
+    private Label type;
+    @FXML
+    private Label bedroom;
+    @FXML
+    private Label bathroom;
+    @FXML
+    private Label floorArea;
+    @FXML
+    private Label status;
+    @FXML
+    private Label listing;
     @FXML
     private Label owner;
+    @FXML
+    private Label buyerIds;
+    @FXML
+    private Label sellerIds;
 
     /**
      * Creates a {@code PropertyCard} with the given {@code Property} and index to display.
@@ -42,26 +56,37 @@ public class PropertyCard extends UiPart<Region> {
         propertyIndex.setText(displayedIndex + ".");
         propertyAddress.setText(property.getPropertyAddress().value);
         propertyUuid.setText("id: " + property.getUuid().getValue());
+        postal.setText("Postal Code: " + property.getPostal().value);
+        type.setText("Type: " + property.getType().value);
+        bedroom.setText("Bedrooms: " + property.getBedroom().value);
+        bathroom.setText("Bathrooms: " + property.getBathroom().value);
+        floorArea.setText("Floor Area: " + property.getFloorArea().value + " sqft");
+        price.setText("Price: $" + String.format("%,d", Integer.parseInt(property.getPrice().value)));
+        status.setText("Status: " + property.getStatus().value);
+        listing.setText("Listing: " + property.getListing().value);
+        owner.setText("Owner ID: " + property.getOwner().value);
 
-        // Format: "type • beds beds • baths baths • sqft sqft"
-        details.setText(String.format("%s • %s beds • %s baths • %s sqft",
-                property.getType().value,
-                property.getBedroom().value,
-                property.getBathroom().value,
-                property.getFloorArea().value));
+        setIdsIfNotEmpty(buyerIds, "Buyer IDs: ", property.getBuyingContactIds());
+        setIdsIfNotEmpty(sellerIds, "Seller IDs: ", property.getSellingContactIds());
+    }
 
-        // Format price with commas and status
-        String formattedPrice = String.format("$%,d • %s • %s",
-                Integer.parseInt(property.getPrice().value),
-                property.getStatus().value,
-                property.getListing().value);
-        price.setText(formattedPrice);
 
-        owner.setText("Owner: " + property.getOwner().value);
+    /**
+     * Hides a label by making it invisible and unmanaged.
+     */
+    private void hideLabel(Label label) {
+        label.setVisible(false);
+        label.setManaged(false);
+    }
 
-        String formattedLinkedIds = String.format("Buyer Ids: %s • Seller Ids: %s",
-                Uuid.getGuiSetDisplayAsString(property.getBuyingContactIds()),
-                Uuid.getGuiSetDisplayAsString(property.getSellingContactIds()));
-        linkedIds.setText(formattedLinkedIds);
+    /**
+     * Sets property IDs if not empty, otherwise hides the label.
+     */
+    private void setIdsIfNotEmpty(Label label, String prefix, java.util.Set<Uuid> ids) {
+        if (ids.isEmpty()) {
+            hideLabel(label);
+        } else {
+            label.setText(prefix + Uuid.getGuiSetDisplayAsString(ids));
+        }
     }
 }

--- a/src/main/resources/view/PropertyListCard.fxml
+++ b/src/main/resources/view/PropertyListCard.fxml
@@ -22,10 +22,17 @@
                 <Label fx:id="propertyAddress" styleClass="cell_property_address" text="\$address" />
             </HBox>
             <Label fx:id="propertyUuid" styleClass="cell_small_label" text="\$uuid" />
-            <Label fx:id="details" styleClass="cell_small_label" text="\$details" />
+            <Label fx:id="postal" styleClass="cell_small_label" text="\$postal" />
+            <Label fx:id="type" styleClass="cell_small_label" text="\$type" />
+            <Label fx:id="bedroom" styleClass="cell_small_label" text="\$bedroom" />
+            <Label fx:id="bathroom" styleClass="cell_small_label" text="\$bathroom" />
+            <Label fx:id="floorArea" styleClass="cell_small_label" text="\$floorArea" />
             <Label fx:id="price" styleClass="cell_small_label" text="\$price" />
+            <Label fx:id="status" styleClass="cell_small_label" text="\$status" />
+            <Label fx:id="listing" styleClass="cell_small_label" text="\$listing" />
             <Label fx:id="owner" styleClass="cell_small_label" text="\$owner" />
-            <Label fx:id="linkedIds" styleClass="cell_small_label" text="\$linkedIds" />
+            <Label fx:id="buyerIds" styleClass="cell_small_label" text="\$buyerIds" />
+            <Label fx:id="sellerIds" styleClass="cell_small_label" text="\$sellerIds" />
         </VBox>
     </GridPane>
 </HBox>


### PR DESCRIPTION
Resolves #169 
Resolves #189 

## Changes
- Add individual labels for all property fields in PropertyCard
- Display each field on a new line for better readability:
  - id
  - Postal Code
  - Type
  - Bedrooms
  - Bathrooms  
  - Floor Area
  - Price
  - Status
  - Listing
  - Owner ID
  - Buyer IDs (separate line)
  - Seller IDs (separate line)
  
  
## Screenshots
<img width="485" height="396" alt="image" src="https://github.com/user-attachments/assets/55b52082-63fb-49d0-8d34-e99bd0662658" />

<img width="1418" height="751" alt="image" src="https://github.com/user-attachments/assets/13c966b5-cf3a-40ca-b26c-cdfd01f515bb" />

